### PR TITLE
Create .eslintrc.json

### DIFF
--- a/stackle_api/.eslintrc.json
+++ b/stackle_api/.eslintrc.json
@@ -1,0 +1,3 @@
+"parserOptions": {
+   "ecmaVersion": 6
+ }


### PR DESCRIPTION
Creating a .eslintrc file to specify the kind of js features used.
Right now, I have only added
```
"parserOptions": {
   "ecmaVersion": 6
 }
```
This will change the ECMA version to 6, instead of the default 5
which will eliminate a few linting errors like 'reserved keywords'.
We can continue to add more to this `.eslintrc.json`.