### PR TITLE
Modularize api

### DIFF
--- a/stackle_api/app/routes/api_v1/index.js
+++ b/stackle_api/app/routes/api_v1/index.js
@@ -1,0 +1,17 @@
+/**
+ * Created by bhavyaagg on 17/02/18.
+ */
+
+const express = require('express');
+const router = express.Router();
+
+router.use('/org', require('./org'));
+router.use('/orgs', require('./orgs'));
+router.use('/post', require('./post'));
+router.use('/posts', require('./posts'));
+router.use('/stack', require('./stack'));
+router.use('/user', require('./user'));
+
+router.use('/', require('./misc'));
+
+exports = module.exports = router;

--- a/stackle_api/app/routes/api_v1/misc.js
+++ b/stackle_api/app/routes/api_v1/misc.js
@@ -1,0 +1,77 @@
+/**
+ * Created by bhavyaagg on 18/02/18.
+ */
+
+
+// The routes present here has to be sorted into meaningful routes
+
+const express = require('express');
+const router = express.Router();
+
+const postModels = require('../../models/post')
+const Stack = require('../../models/stack');
+const User = require('../../models/user');
+
+const Post = postModels.Post;
+const Comment = postModels.Comment;
+
+//api
+router.get('/login', function (req, res) {
+})
+
+//comment on a post
+router.post('/comment/:postid', function (req, res) {
+    let postid = req.params.postid;
+    let query = {_id: postid};
+    let comment = new Comment(req.body);
+    Post.update(query, {comments: []});
+})
+
+
+
+//delete stack
+router.delete('/delete/stack/:stackid', function (req, res) {
+    let stack_id = req.params.stackid;
+    Stack.remove({_id: stack_id}, function (err, success) {
+        if (err) {
+            res.send("Couldn't delete Stack");
+        } else {
+            res.send("")
+        }
+    })
+})
+
+//user subscribing to an stack
+router.post('/subscribe', function (req, res) {
+    let userid = req.body.uid;
+    let stackname = req.body.stack_name;
+    let query = {userId: userid};
+    User.findOneAndUpdate(query, {$push: {subscribed_stacks: stackname}}, function (err, noaffected) {
+        if (err) {
+            res.send("Error Updating");
+        } else {
+            res.send("Success!!");
+        }
+    });
+})
+
+
+
+//create user
+router.post('/newuser', function (req, res) {
+    let user = new User(req.body);
+    user.save(function (err, user) {
+        if (err) {
+            console.log("Error saving the stack to database");
+            res.send("Error saving user!");
+        } else {
+            res.send("Sucessfully created the user");
+        }
+    })
+})
+
+router.get('/notifications', function (req, res) {
+});
+
+
+exports = module.exports = router;

--- a/stackle_api/app/routes/api_v1/misc.js
+++ b/stackle_api/app/routes/api_v1/misc.js
@@ -8,7 +8,7 @@
 const express = require('express');
 const router = express.Router();
 
-const postModels = require('../../models/post')
+const postModels = require('../../models/post');
 const Stack = require('../../models/stack');
 const User = require('../../models/user');
 
@@ -31,12 +31,12 @@ router.post('/comment/:postid', function (req, res) {
 
 //delete stack
 router.delete('/delete/stack/:stackid', function (req, res) {
-    let stack_id = req.params.stackid;
-    Stack.remove({_id: stack_id}, function (err, success) {
+    let stackId = req.params.stackid;
+    Stack.remove({_id: stackId}, function (err, success) {
         if (err) {
             res.send("Couldn't delete Stack");
         } else {
-            res.send("")
+            res.send("Stack Deleted");
         }
     })
 })

--- a/stackle_api/app/routes/api_v1/misc.js
+++ b/stackle_api/app/routes/api_v1/misc.js
@@ -17,7 +17,7 @@ const Comment = postModels.Comment;
 
 //api
 router.get('/login', function (req, res) {
-})
+});
 
 //comment on a post
 router.post('/comment/:postid', function (req, res) {
@@ -25,7 +25,7 @@ router.post('/comment/:postid', function (req, res) {
     let query = {_id: postid};
     let comment = new Comment(req.body);
     Post.update(query, {comments: []});
-})
+});
 
 
 
@@ -38,8 +38,8 @@ router.delete('/delete/stack/:stackid', function (req, res) {
         } else {
             res.send("Stack Deleted");
         }
-    })
-})
+    });
+});
 
 //user subscribing to an stack
 router.post('/subscribe', function (req, res) {
@@ -53,7 +53,7 @@ router.post('/subscribe', function (req, res) {
             res.send("Success!!");
         }
     });
-})
+});
 
 
 
@@ -67,8 +67,8 @@ router.post('/newuser', function (req, res) {
         } else {
             res.send("Sucessfully created the user");
         }
-    })
-})
+    });
+});
 
 router.get('/notifications', function (req, res) {
 });

--- a/stackle_api/app/routes/api_v1/org.js
+++ b/stackle_api/app/routes/api_v1/org.js
@@ -18,7 +18,7 @@ router.get('/:orgname', function (req, res) {
         } else {
             res.send(org);
         }
-    })
-})
+    });
+});
 
 exports = module.exports = router;

--- a/stackle_api/app/routes/api_v1/org.js
+++ b/stackle_api/app/routes/api_v1/org.js
@@ -1,0 +1,24 @@
+/**
+ * Created by bhavyaagg on 18/02/18.
+ */
+
+const express = require('express');
+const router = express.Router();
+
+const Stack = require('../../models/stack');
+
+//get a specific org
+router.get('/:orgname', function (req, res) {
+    res.header("Access-Control-Allow-Origin", "*");
+    res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
+    let orgname = req.params.orgname;
+    Stack.find({name: orgname}, function (err, org) {
+        if (err) {
+            console.log('Error');
+        } else {
+            res.send(org);
+        }
+    })
+})
+
+exports = module.exports = router;

--- a/stackle_api/app/routes/api_v1/orgs.js
+++ b/stackle_api/app/routes/api_v1/orgs.js
@@ -10,11 +10,12 @@ const Stack = require('../../models/stack');
 //get all stacks (orgs)
 router.get('/', function (req, res) {
     Stack.find({}, function (err, stacks) {
-        if (err)
+        if (err) {
             console.log("Errors retrieving stacks!");
-        else
+        } else {
             res.send(stacks);
-    })
-})
+        }
+    });
+});
 
 exports = module.exports = router;

--- a/stackle_api/app/routes/api_v1/orgs.js
+++ b/stackle_api/app/routes/api_v1/orgs.js
@@ -1,0 +1,20 @@
+/**
+ * Created by bhavyaagg on 18/02/18.
+ */
+
+const express = require('express');
+const router = express.Router();
+
+const Stack = require('../../models/stack');
+
+//get all stacks (orgs)
+router.get('/', function (req, res) {
+    Stack.find({}, function (err, stacks) {
+        if (err)
+            console.log("Errors retrieving stacks!");
+        else
+            res.send(stacks);
+    })
+})
+
+exports = module.exports = router;

--- a/stackle_api/app/routes/api_v1/post.js
+++ b/stackle_api/app/routes/api_v1/post.js
@@ -1,0 +1,40 @@
+/**
+ * Created by bhavyaagg on 17/02/18.
+ */
+const express = require('express');
+const router = express.Router();
+
+const postModels = require('../../models/post')
+
+const Post = postModels.Post;
+
+//get a post by id
+router.get('/:postid', function (req, res) {
+    res.header("Access-Control-Allow-Origin", "*");
+    res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
+    let objectid = req.params.postid;
+    Post.findOne({_id: objectid}, function (err, post) {
+        if (err) {
+            res.send(err)
+        } else {
+            res.send(post);
+        }
+    })
+})
+
+//delete a post by ID
+router.delete('/api/post/:postid', function (req, res) {
+    let postid = req.params.postid;
+    Post.remove({_id: postid}, function (err, success) {
+        if (err) {
+            console.log(err);
+            res.send("Error deleting the document");
+        } else if (success) {
+            res.send("Sucessfully Deleted");
+        } else {
+            console.log("Null pointer");
+        }
+    })
+})
+
+exports = module.exports = router;

--- a/stackle_api/app/routes/api_v1/post.js
+++ b/stackle_api/app/routes/api_v1/post.js
@@ -4,23 +4,23 @@
 const express = require('express');
 const router = express.Router();
 
-const postModels = require('../../models/post')
+const postModels = require('../../models/post');
 
 const Post = postModels.Post;
 
 //get a post by id
-router.get('/:postid', function (req, res) {
+router.get('/:postId', function (req, res) {
     res.header("Access-Control-Allow-Origin", "*");
     res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
-    let objectid = req.params.postid;
-    Post.findOne({_id: objectid}, function (err, post) {
+    let objectId = req.params.postId;
+    Post.findOne({_id: objectId}, function (err, post) {
         if (err) {
-            res.send(err)
+            res.send(err);
         } else {
             res.send(post);
         }
-    })
-})
+    });
+});
 
 //delete a post by ID
 router.delete('/api/post/:postid', function (req, res) {
@@ -34,7 +34,7 @@ router.delete('/api/post/:postid', function (req, res) {
         } else {
             console.log("Null pointer");
         }
-    })
-})
+    });
+});
 
 exports = module.exports = router;

--- a/stackle_api/app/routes/api_v1/posts.js
+++ b/stackle_api/app/routes/api_v1/posts.js
@@ -5,7 +5,7 @@
 const express = require('express');
 const router = express.Router();
 
-const postModels = require('../../models/post')
+const postModels = require('../../models/post');
 
 const Post = postModels.Post;
 
@@ -14,34 +14,36 @@ router.get('/', function (req, res) {
     res.header("Access-Control-Allow-Origin", "*");
     res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
     Post.find({}, function (err, posts) {
-        if (err)
-            console.log("Cant get all posts!")
+        if (err) {
+            console.log("Cant get all posts!");
+        }
         res.send(posts);
-    })
-})
+    });
+});
 
 //returns posts by a specific user
 router.get('/:user', function (req, res) {
     let id = req.params.user;
     Post.find({user: id}, function (err, posts) {
-        if (err)
+        if (err) {
             console.log("Erorr getting posts");
+        }
         res.send(posts);
-    })
-})
+    });
+});
 
 //returns posts relating to specific org
-router.get('/org/:org_name', function (req, res) {
+router.get('/org/:orgName', function (req, res) {
     res.header("Access-Control-Allow-Origin", "*");
     res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
-    let orgname = req.params.org_name;
-    Post.find({org_name: orgname}, function (err, posts) {
+    let orgName = req.params.orgName;
+    Post.find({org_name: orgName}, function (err, posts) {
         if (err) {
             console.log(`Error getting posts from $orgname`);
-        }
-        else
+        } else {
             res.send(posts);
-    })
-})
+        }
+    });
+});
 
 exports = module.exports = router;

--- a/stackle_api/app/routes/api_v1/posts.js
+++ b/stackle_api/app/routes/api_v1/posts.js
@@ -1,0 +1,47 @@
+/**
+ * Created by bhavyaagg on 17/02/18.
+ */
+
+const express = require('express');
+const router = express.Router();
+
+const postModels = require('../../models/post')
+
+const Post = postModels.Post;
+
+//get all posts
+router.get('/', function (req, res) {
+    res.header("Access-Control-Allow-Origin", "*");
+    res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
+    Post.find({}, function (err, posts) {
+        if (err)
+            console.log("Cant get all posts!")
+        res.send(posts);
+    })
+})
+
+//returns posts by a specific user
+router.get('/:user', function (req, res) {
+    let id = req.params.user;
+    Post.find({user: id}, function (err, posts) {
+        if (err)
+            console.log("Erorr getting posts");
+        res.send(posts);
+    })
+})
+
+//returns posts relating to specific org
+router.get('/org/:org_name', function (req, res) {
+    res.header("Access-Control-Allow-Origin", "*");
+    res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
+    let orgname = req.params.org_name;
+    Post.find({org_name: orgname}, function (err, posts) {
+        if (err) {
+            console.log(`Error getting posts from $orgname`);
+        }
+        else
+            res.send(posts);
+    })
+})
+
+exports = module.exports = router;

--- a/stackle_api/app/routes/api_v1/stack.js
+++ b/stackle_api/app/routes/api_v1/stack.js
@@ -37,8 +37,8 @@ router.get('/subscribed/:userId', function (req, res) {
         } else {
             res.send("Can't get!");
         }
-    })
-})
+    });
+});
 
 
 exports = module.exports = router;

--- a/stackle_api/app/routes/api_v1/stack.js
+++ b/stackle_api/app/routes/api_v1/stack.js
@@ -1,0 +1,44 @@
+/**
+ * Created by bhavyaagg on 18/02/18.
+ */
+
+const express = require('express');
+const router = express.Router();
+
+const Stack = require('../../models/stack');
+const User = require('../../models/user');
+
+//create stack
+router.post('/create', function (req, res) {
+    let stack = new Stack(req.body);
+    stack.save(function (err, stack) {
+        if (err) {
+            console.log("Error saving the stack to database");
+            res.send("Error saving stack!");
+        } else if (stack) {
+            res.send("Sucessfully created the stack");
+        } else {
+            res.send("Null");
+        }
+    })
+})
+
+//getting subscribed stacks for a user
+router.get('/subscribed/:userid', function (req, res) {
+    res.header("Access-Control-Allow-Origin", "*");
+    res.header('Access-Control-Allow-Methods: GET, POST, PATCH, PUT, DELETE, OPTIONS');
+    res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
+    User.findOne({userId: req.params.userid}, function (err, result) {
+        if (err) {
+            res.send(err);
+        } else if (result) {
+            let sub_stack = result.subscribed_stacks;
+            res.send(sub_stack);
+        } else {
+            res.send("Can't get!");
+        }
+    })
+})
+
+
+exports = module.exports = router;

--- a/stackle_api/app/routes/api_v1/stack.js
+++ b/stackle_api/app/routes/api_v1/stack.js
@@ -20,20 +20,20 @@ router.post('/create', function (req, res) {
         } else {
             res.send("Null");
         }
-    })
-})
+    });
+});
 
 //getting subscribed stacks for a user
-router.get('/subscribed/:userid', function (req, res) {
+router.get('/subscribed/:userId', function (req, res) {
     res.header("Access-Control-Allow-Origin", "*");
     res.header('Access-Control-Allow-Methods: GET, POST, PATCH, PUT, DELETE, OPTIONS');
     res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
-    User.findOne({userId: req.params.userid}, function (err, result) {
+    User.findOne({userId: req.params.userId}, function (err, result) {
         if (err) {
             res.send(err);
         } else if (result) {
-            let sub_stack = result.subscribed_stacks;
-            res.send(sub_stack);
+            let subStack = result.subscribed_stacks;
+            res.send(subStack);
         } else {
             res.send("Can't get!");
         }

--- a/stackle_api/app/routes/api_v1/user.js
+++ b/stackle_api/app/routes/api_v1/user.js
@@ -4,7 +4,7 @@
 const express = require('express');
 const router = express.Router();
 
-const postModels = require('../../models/post')
+const postModels = require('../../models/post');
 
 const Post = postModels.Post;
 
@@ -14,11 +14,11 @@ router.post('/post', function (req, res) {
     post.save(function (err, post) {
         if (err) {
             console.log("error saving the post");
-            res.send("error!")
+            res.send("error!");
         } else {
             res.send("Sucessfully saved the post!");
         }
     });
-})
+});
 
 exports = module.exports = router;

--- a/stackle_api/app/routes/api_v1/user.js
+++ b/stackle_api/app/routes/api_v1/user.js
@@ -1,0 +1,24 @@
+/**
+ * Created by bhavyaagg on 17/02/18.
+ */
+const express = require('express');
+const router = express.Router();
+
+const postModels = require('../../models/post')
+
+const Post = postModels.Post;
+
+//save a post
+router.post('/post', function (req, res) {
+    let post = new Post(req.body);
+    post.save(function (err, post) {
+        if (err) {
+            console.log("error saving the post");
+            res.send("error!")
+        } else {
+            res.send("Sucessfully saved the post!");
+        }
+    });
+})
+
+exports = module.exports = router;

--- a/stackle_api/app/routes/misc.js
+++ b/stackle_api/app/routes/misc.js
@@ -10,7 +10,7 @@ const router = express.Router();
 router.get('/home', function (req, res) {
     //needs to intergrate with github for implementation
     res.end();
-})
+});
 
 router.get('/*', function (req, res) {
     res.sendfile('./public/404.html');

--- a/stackle_api/app/routes/misc.js
+++ b/stackle_api/app/routes/misc.js
@@ -1,0 +1,19 @@
+/**
+ * Created by bhavyaagg on 18/02/18.
+ */
+
+// The routes present here has to be sorted into meaningful routes
+
+const express = require('express');
+const router = express.Router();
+
+router.get('/home', function (req, res) {
+    //needs to intergrate with github for implementation
+    res.end();
+})
+
+router.get('/*', function (req, res) {
+    res.sendfile('./public/404.html');
+});
+
+exports = module.exports = router;

--- a/stackle_api/server.js
+++ b/stackle_api/server.js
@@ -2,44 +2,49 @@ require('dotenv').config();
 const express = require('express');
 const app = express();
 const path = require('path');
-var mongoose = require('mongoose'); 
+var mongoose = require('mongoose');
 var database = require('./config/database');            // load the database config
 var morgan = require('morgan');             // log requests to the console (express4)
 var bodyParser = require('body-parser');    // pull information from HTML POST (express4)
 var methodOverride = require('method-override'); // simulate DELETE and PUT (express4)
 var db = mongoose.connection;
 
-app.use('/', express.static(__dirname +  '/'));
+app.use('/', express.static(__dirname + '/'));
 app.use(morgan('dev'));                                         // log every request to the console
-app.use(bodyParser.urlencoded({'extended':'true'}));            // parse application/x-www-form-urlencoded
+app.use(bodyParser.urlencoded({'extended': 'true'}));            // parse application/x-www-form-urlencoded
 app.use(bodyParser.json());                                     // parse application/json
-app.use(bodyParser.json({ type: 'application/vnd.api+json' })); // parse application/vnd.api+json as json
+app.use(bodyParser.json({type: 'application/vnd.api+json'})); // parse application/vnd.api+json as json
 app.use(methodOverride());
 
 
-var routes = require('./app/routes')(app,db);
+// var routes = require('./app/routes')(app,db);
+
+app.use('/api', require('./app/routes/api_v1'))
+
+// The routes present here has to be sorted into meaningful routes
+app.use('/', require('./app/routes/misc'));
 
 
 app.use(function (err, req, res, next) {
-  res.header("Access-Control-Allow-Origin", "http://localhost:8082");
-  res.header('Access-Control-Allow-Methods', 'GET, PUT, POST, DELETE, OPTIONS');
-  res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
-  console.error(err.stack);
-  res.status(500).send('Something broke!')
+    res.header("Access-Control-Allow-Origin", "http://localhost:8082");
+    res.header('Access-Control-Allow-Methods', 'GET, PUT, POST, DELETE, OPTIONS');
+    res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
+    console.error(err.stack);
+    res.status(500).send('Something broke!')
 });
 
 const hostname = 'localhost';
 
-mongoose.connect(database.url,function(err){
+mongoose.connect(database.url, function (err) {
     console.log("Connecting to the database..");
-    if(err){
-        mongoose.connect(database.alturl,function(err){
+    if (err) {
+        mongoose.connect(database.alturl, function (err) {
             return console.log(err);
         })
         return console.log("Couldnt connect to db url 1. connecting to alternate");
-    }else{
+    } else {
         console.log("Mongo connect sucess!");
-    }  
+    }
 });     // connect to mongoDB database on modulus.io
 
 module.exports = app;

--- a/stackle_api/server.js
+++ b/stackle_api/server.js
@@ -18,7 +18,7 @@ app.use(methodOverride());
 
 // var routes = require('./app/routes')(app,db);
 
-app.use('/api', require('./app/routes/api_v1'))
+app.use('/api', require('./app/routes/api_v1'));
 
 // The routes present here has to be sorted into meaningful routes
 app.use('/', require('./app/routes/misc'));


### PR DESCRIPTION
I have modularized the API routes.
But i think there are some parts which can be improved:

1) 
HTTP verbs should not be present in the URL
https://github.com/scorelab/Stackle/blob/master/stackle_api/app/routes.js#L148

HTTP verb "delete" is also used in the URL

2)
Singular and Plural both are used for an object in the URL
i.e. 
We have used /posts as well as /post. 
https://github.com/scorelab/Stackle/blob/master/stackle_api/app/routes.js#L25
https://github.com/scorelab/Stackle/blob/master/stackle_api/app/routes.js#L49

It should be /api/posts and /api/posts/:postid respectively

Same for orgs and org

3)
https://github.com/scorelab/Stackle/blob/master/stackle_api/app/routes.js#L160
This can be /api/stack/subscribe

These are just my opinions. I know I might be wrong. But would love to work on Stackle :)


