### PR TITLE
stackle_app readme file update

### DIFF
--- a/stackle_app/README.md
+++ b/stackle_app/README.md
@@ -5,8 +5,8 @@ version 0.16.0.
 
 ## Build & development
 
-Run `grunt` for building and `grunt serve` for preview.
+Run `gulp` for building and `gulp serve` for preview.
 
 ## Testing
 
-Running `grunt test` will run the unit tests with karma.
+Running `gulp test` will run the unit tests with karma.


### PR DESCRIPTION
Use gulp instead of grunt for building, testing and serving (live preview).